### PR TITLE
Add blue color to weblinks

### DIFF
--- a/diss.tex
+++ b/diss.tex
@@ -230,7 +230,11 @@
 %%   rather than the entry text.
 \usepackage[bookmarks,bookmarksnumbered,%
     allbordercolors={0.8 0.8 0.8},%
-    pagebackref,linktocpage%
+    pagebackref,linktocpage,%
+    colorlinks=true,%
+    linkcolor=black,%
+    urlcolor=blue,%
+    citecolor=black%
     ]{hyperref}
 %% The following change how the the back-references text is typeset in a
 %% bibliography when `backref' or `pagebackref' are used


### PR DESCRIPTION
As per https://www.grad.ubc.ca/current-students/dissertation-thesis-preparation/fonts-print
weblinks should be dark blue.